### PR TITLE
Fix Bug (See description below)

### DIFF
--- a/UML_MANAGER/uml_manager.py
+++ b/UML_MANAGER/uml_manager.py
@@ -342,7 +342,7 @@ def get_file_name_to_save() -> str:
         if not is_saving:
             print("\nCanceled saving!")
             return
-        name_list.append({file_name: "on"})
+        name_list.append({file_name: "off"})
         UML_STORAGE_MANAGER.save_name_list(name_list)
     return file_name  # Return the file name
 


### PR DESCRIPTION
Before: When a file is loaded to retrieve its data and then saved under a different name (cloned), the status indicates that both files are active.

After: The newly saved (cloned) file will not be marked as active; only the currently loaded file will have an active status.