### PR TITLE
Fix Bug ( Hopefully this is the final one :( )

### DIFF
--- a/UML_MANAGER/uml_manager.py
+++ b/UML_MANAGER/uml_manager.py
@@ -458,6 +458,7 @@ def reset_storage():
 def end_session():
     set_all_file_off()
     reset_storage()
+    keep_updating_data()
     print("\nSuccessfully back to default program!")
 
 


### PR DESCRIPTION
-Before: When we load a file, then type "default" command, it does not properly return to blank program but still has connection to the previous loaded file.

-After: Properly return to blank program when we use "default" with currently loaded file